### PR TITLE
quick fix for PNG upload

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -46,7 +46,7 @@ def detectFaceOpenCVDnn(net, frame, framework="caffe", conf_threshold=0.5):
 uploaded_file = st.file_uploader("Choose a file", type =['jpg','jpeg','jfif','png'])
 net = load_model()
 if uploaded_file is not None:
-    image = np.array(Image.open(uploaded_file))
+    image = np.array(Image.open(uploaded_file))[..., :3]
     
     placeholders = st.beta_columns(2)
     placeholders[0].image(image)


### PR DESCRIPTION
When a four-channel photo is uploaded "PNG it throws an error, this is a quick fix to neglect the fourth channel "alpha channel".
![image](https://user-images.githubusercontent.com/54246638/172624004-e09bf8dc-3abe-4294-a1a3-4327349776e1.png)